### PR TITLE
Use local for unpacked variables

### DIFF
--- a/config.lua
+++ b/config.lua
@@ -1,4 +1,4 @@
-bdlc, l, f = select(2, ...):unpack()
+local bdlc, l, f = select(2, ...):unpack()
 local config
 local defaults = {}
 local ranks = {}

--- a/core.lua
+++ b/core.lua
@@ -1,4 +1,4 @@
-bdlc, l, f = select(2, ...):unpack()
+local bdlc, l, f = select(2, ...):unpack()
 
 local AceComm = LibStub:GetLibrary("AceComm-3.0")
 GetNumGuildMembers()

--- a/frames.lua
+++ b/frames.lua
@@ -1,4 +1,4 @@
-bdlc, l, f = select(2, ...):unpack()
+local bdlc, l, f = select(2, ...):unpack()
 
 f.rolls = {}
 f.tabs = {}

--- a/init.lua
+++ b/init.lua
@@ -3,9 +3,9 @@ engine[1] = CreateFrame("Frame", nil, UIParent)
 engine[2] = {}
 engine[3] = {}
 
-bdlc = engine[1]
-l = engine[2]
-f = engine[3]
+local bdlc = engine[1]
+local l = engine[2]
+local f = engine[3]
 
 function engine:unpack()
 	return self[1], self[2], self[3]

--- a/localization.lua
+++ b/localization.lua
@@ -1,4 +1,4 @@
-bdlc, l, f = select(2, ...):unpack()
+local bdlc, l, f = select(2, ...):unpack()
 
 --------------------------------------
 -- EN Localization Defaults (dont touch, use as reference)

--- a/loot_council.lua
+++ b/loot_council.lua
@@ -1,4 +1,4 @@
-bdlc, l, f = select(2, ...):unpack()
+local bdlc, l, f = select(2, ...):unpack()
 
 function bdlc:inLC()
 	return bdlc.loot_council[FetchUnitName("player")] or IsRaidLeader() or not IsInRaid()

--- a/versions.lua
+++ b/versions.lua
@@ -1,4 +1,4 @@
-bdlc, l, f = select(2, ...):unpack()
+local bdlc, l, f = select(2, ...):unpack()
 bdlc.versions = {}
 
 --------------------------------------------------


### PR DESCRIPTION
This prevents nil references when another addon reuses the same variable names. Fairly commonly occurring with 'f' variable.

Example errors:
![image](https://user-images.githubusercontent.com/5223519/58752691-762fc300-8481-11e9-8a86-99b47dcf18db.png)
