### PR TITLE
Fix double-comma which causes lua errors

### DIFF
--- a/config.lua
+++ b/config.lua
@@ -49,7 +49,7 @@ function bdlc:SetupConfiguration()
 			}, defaults, "bdlc_config")
 		end
 
-		bg_do_action("guild_info_available")
+		bd_do_action("guild_info_available")
 	end)
 	
 end

--- a/config.lua
+++ b/config.lua
@@ -39,7 +39,7 @@ function bdlc:SetupConfiguration()
 				, value = defaultRank
 				, label = "Minimum LC Rank"
 				, update = function(self, dropdown) bdlc:UpdateRanks(dropdown) end
-				, update_action = "guild_info_available",
+				, update_action = "guild_info_available"
 				, options = ranks
 				, label = "Minimum Loot Council Rank"
 			}}

--- a/libs/bdConfigLib1.0.lua
+++ b/libs/bdConfigLib1.0.lua
@@ -1317,7 +1317,7 @@ do
 				else
 					save.profiles[value] = save.profile
 					bdConfigLibProfiles.Selected = value
-					bg_do_action("update_profiles")
+					bd_do_action("update_profiles")
 				end
 			end
 		end


### PR DESCRIPTION
Fixes Lua errors:
```
bigdumblootcouncil\config.lua:43: unexpected symbol near ','
bigdumblootcouncil\core.lua:886: attempt to call method 'SetupConfiguration' (a nil value)
```

```
bigdumblootcouncil\config.lua:52: attempt to call global 'bg_do_action' (a nil value)
```