### PR TITLE
Fix award lua error, add whisper for trade action

### DIFF
--- a/frames.lua
+++ b/frames.lua
@@ -101,11 +101,13 @@ end
 local function awardLoot(playerName, dropdown, itemUID)
 	playerName = FetchUnitName(playerName)
 	if (not itemUID) then return end
+	local lootedBy = bdlc.loot_sessions[itemUID]
 	local itemLink = bdlc.itemMap[itemUID]
 	if (not itemLink) then return end
 
 	SendChatMessage("BDLC: "..itemLink.." awarded to "..playerName, "RAID")
-	bdlc:sendAction("addLootHistory", itemUID, name)
+	SendChatMessage("BDLC: Please trade "..itemLink.." to "..playerName, "WHISPER", nil, lootedBy)
+	bdlc:sendAction("addLootHistory", itemUID, playerName)
 
 	dropdown:Hide()
 end


### PR DESCRIPTION
When awarding gear I was getting a LUA error, on inspection it seems the `name` parameter is undefined in the `sendAction` call here.

![image](https://user-images.githubusercontent.com/89693/67440784-ecaf9780-f5bf-11e9-8f5f-e1e896450af6.png)

Additionally I added a feature to whisper the person with the gear to trade it to the awarded person.