### PR TITLE
Make sure myilvl is a number in case of bad messages

### DIFF
--- a/core/session.lua
+++ b/core/session.lua
@@ -246,7 +246,7 @@ function bdlc:addUserWant(itemUID, playerName, want, itemLink1, itemLink2, roll,
 	entry.interest.text:SetTextColor(unpack(wantColor))
 	entry.voteUser:Show()
 	entry.roll = roll
-	entry.myilvl = tonumber(ilvl)
+	entry.myilvl = tonumber(ilvl) or 0
 	entry.wantLevel = want
 	entry.itemUID = itemUID
 	entry.playerName = playerName


### PR DESCRIPTION
Not sure what causes these bad messages (from what it appears), but this should at least prevent it from bombing out.

The error:

  
```
46x bigdumblootcouncil\core\frames.lua:48: attempt to compare nil with number
[string "@bigdumblootcouncil\core\frames.lua"]:48: in function <bigdumblootcouncil\core\frames.lua:38>
[string "=(tail call)"]: ?
[string "=[C]"]: in function `sort'
[string "@bigdumblootcouncil\core\functions.lua"]:62: in function `spairs'
[string "@bigdumblootcouncil\core\frames.lua"]:38: in function `repositionFrames'
[string "@bigdumblootcouncil\core\session.lua"]:99: in function `createVoteWindow'
[string "@bigdumblootcouncil\core\session.lua"]:23: in function `?'
[string "@bigdumblootcouncil\core\session.lua"]:560: in function `messageCallback'
[string "@bigdumblootcouncil\core\load.lua"]:12: in function <bigdumblootcouncil\core\load.lua:11>
[string "=[C]"]: ?
[string "@Scrap\libs\CallbackHandler-1.0\CallbackHandler-1.0-7.lua"]:29: in function <...rap\libs\CallbackHandler-1.0\CallbackHandler-1.0.lua:25>
[string "@Scrap\libs\CallbackHandler-1.0\CallbackHandler-1.0-7.lua"]:64: in function `Fire'
[string "@AngryAssignments\libs\AceComm-3.0\AceComm-3.0-12.lua"]:264: in function <...ns\AngryAssignments\libs\AceComm-3.0\AceComm-3.0.lua:246>
```